### PR TITLE
bug fix: GPS_Time.fromWeekSow

### DIFF
--- a/goGPS/obj/utils/GPS_Time.m
+++ b/goGPS/obj/utils/GPS_Time.m
@@ -1889,7 +1889,7 @@ classdef GPS_Time < Exportable & handle
             %
             % SYNTAX
             %   this = GPS_Time.fromWeekSow(week, sow)
-            this = GPS_Time.fromWeekDow(week, (dow) / 86400);
+            this = GPS_Time.fromWeekDow(week, (sow) / 86400);
         end
         
         function this = fromDoySod(year, doy, sod)


### PR DESCRIPTION
Typo in variable name? "dow" was not defined.